### PR TITLE
Fast-foward de fisop/alloc con los últimos fixes a grade-lab-alloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OBJS = \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
-#TOOLPREFIX = 
+#TOOLPREFIX =
 
 # Try to infer the correct TOOLPREFIX if not set
 ifndef TOOLPREFIX
@@ -74,7 +74,7 @@ endif
 LDFLAGS = -z max-page-size=4096
 
 $K/kernel: $(OBJS) $K/kernel.ld $U/initcode
-	$(LD) $(LDFLAGS) -T $K/kernel.ld -o $K/kernel $(OBJS) 
+	$(LD) $(LDFLAGS) -T $K/kernel.ld -o $K/kernel $(OBJS)
 	$(OBJDUMP) -S $K/kernel > $K/kernel.asm
 	$(OBJDUMP) -t $K/kernel | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $K/kernel.sym
 
@@ -150,7 +150,7 @@ fs.img: mkfs/mkfs README user/xargstest.sh $(UPROGS)
 
 -include kernel/*.d user/*.d
 
-clean: 
+clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
 	*/*.o */*.d */*.asm */*.sym \
 	$U/initcode $U/initcode.out $K/kernel fs.img \

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ qemu: $K/kernel fs.img
 	sed "s/:1234/:$(GDBPORT)/" < $^ > $@
 
 qemu-gdb: $K/kernel .gdbinit fs.img
-	@echo "*** Now run 'gdb'." 1>&2
+	@echo "*** Now run 'gdb' in another window." 1>&2
 	$(QEMU) $(QEMUOPTS) -S $(QEMUGDB)
 
 # CUT HERE

--- a/conf/lab-alloc.json
+++ b/conf/lab-alloc.json
@@ -1,0 +1,8 @@
+{
+  "name": "alloc",
+  "commit": "02247fb22b72e8d3851f7834336c319380002117",
+  "keep": [
+    "kernel/buddy.c",
+    "kernel/file.c"
+  ]
+}

--- a/grade-lab-alloc
+++ b/grade-lab-alloc
@@ -5,18 +5,18 @@ from gradelib import *
 
 r = Runner(save("xv6.out"))
 
-@test(30, "alloctest")
+@test(0, "running alloctest")
 def test_alloctest():
     r.run_qemu(shell_script([
         'alloctest'
     ]))
+
+@test(30, "filetest", parent=test_alloctest)
+def test_filetest():
     r.match("^filetest: OK$")
 
-@test(50, "alloctest")
-def test_alloctest():
-    r.run_qemu(shell_script([
-        'alloctest'
-    ]))
+@test(50, "memtest", parent=test_alloctest)
+def test_memtest():
     r.match("^memtest: OK$")
 
 @test(20, "usertests")

--- a/grade-lab-alloc
+++ b/grade-lab-alloc
@@ -7,9 +7,9 @@ r = Runner(save("xv6.out"))
 
 @test(0, "running alloctest")
 def test_alloctest():
-    r.run_qemu(shell_script([
-        'alloctest'
-    ]))
+    r.run_qemu(shell_script(
+        ['alloctest'],
+        terminate_match="^memtest: (OK|FAILED)$|panic: "))
 
 @test(30, "filetest", parent=test_alloctest)
 def test_filetest():
@@ -21,9 +21,9 @@ def test_memtest():
 
 @test(20, "usertests")
 def test_usertests():
-    r.run_qemu(shell_script([
-        'usertests'
-    ]), timeout=150)
+    r.run_qemu(shell_script(['usertests'],
+                            terminate_match=ALL_TESTS_RE),
+               timeout=150)
     r.match('^ALL TESTS PASSED$')
 
 run_tests()

--- a/gradelib.py
+++ b/gradelib.py
@@ -7,6 +7,14 @@ from optparse import OptionParser
 __all__ = []
 
 ##################################################################
+# Default completion regex
+#
+
+__all__ += ["ALL_TESTS_RE"]
+
+ALL_TESTS_RE = "^(SOME TESTS FAILED|ALL TESTS PASSED)$|panic: "
+
+##################################################################
 # Test structure
 #
 
@@ -574,7 +582,8 @@ def shell_script(script, terminate_match=None):
         def handle_output(output):
             context.buf.extend(output)
             if terminate_match is not None:
-                if re.match(terminate_match, context.buf.decode('utf-8', 'replace')):
+                if re.search(terminate_match,
+                             context.buf.decode('utf-8', 'replace'), re.M):
                     raise TerminateTest
             if b'$ ' in context.buf:
                 context.buf = bytearray()

--- a/kernel/buddy.c
+++ b/kernel/buddy.c
@@ -12,7 +12,7 @@ static int nsizes;     // the number of entries in bd_sizes array
 #define LEAF_SIZE     16                         // The smallest block size
 #define MAXSIZE       (nsizes-1)                 // Largest index in bd_sizes array
 #define BLK_SIZE(k)   ((1L << (k)) * LEAF_SIZE)  // Size of block at size k
-#define HEAP_SIZE     BLK_SIZE(MAXSIZE) 
+#define HEAP_SIZE     BLK_SIZE(MAXSIZE)
 #define NBLK(k)       (1 << (MAXSIZE-k))         // Number of block at size k
 #define ROUNDUP(n,sz) (((((n)-1)/(sz))+1)*(sz))  // Round up to the next multiple of sz
 
@@ -31,7 +31,7 @@ struct sz_info {
 };
 typedef struct sz_info Sz_info;
 
-static Sz_info *bd_sizes; 
+static Sz_info *bd_sizes;
 static void *bd_base;   // start address of memory managed by the buddy allocator
 static struct spinlock lock;
 
@@ -60,7 +60,7 @@ void bit_clear(char *array, int index) {
 void
 bd_print_vector(char *vector, int len) {
   int last, lb;
-  
+
   last = 1;
   lb = 0;
   for (int b = 0; b < len; b++) {
@@ -212,7 +212,7 @@ log2(uint64 n) {
   return k;
 }
 
-// Mark memory from [start, stop), starting at size 0, as allocated. 
+// Mark memory from [start, stop), starting at size 0, as allocated.
 void
 bd_mark(void *start, void *stop)
 {
@@ -250,7 +250,7 @@ bd_initfree_pair(int k, int bi) {
   }
   return free;
 }
-  
+
 // Initialize the free lists for each size k.  For each size k, there
 // are only two pairs that may have a buddy that should be on free list:
 // bd_left and bd_right.
@@ -336,12 +336,12 @@ bd_init(void *base, void *end) {
   // done allocating; mark the memory range [base, p) as allocated, so
   // that buddy will not hand out that memory.
   int meta = bd_mark_data_structures(p);
-  
+
   // mark the unavailable memory range [end, HEAP_SIZE) as allocated,
   // so that buddy will not hand out that memory.
   int unavailable = bd_mark_unavailable(end, p);
   void *bd_end = bd_base+BLK_SIZE(MAXSIZE)-unavailable;
-  
+
   // initialize free lists for each size k
   int free = bd_initfree(p, bd_end);
 

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -61,7 +61,7 @@ struct {
 // user write()s to the console go here.
 //
 int
-consolewrite(int user_src, uint64 src, int n)
+consolewrite(struct file *f, int user_src, uint64 src, int n)
 {
   int i;
 
@@ -84,7 +84,7 @@ consolewrite(int user_src, uint64 src, int n)
 // or kernel address.
 //
 int
-consoleread(int user_dst, uint64 dst, int n)
+consoleread(struct file *f, int user_dst, uint64 dst, int n)
 {
   uint target;
   int c;

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -114,6 +114,8 @@ fileread(struct file *f, uint64 addr, int n)
   if(f->type == FD_PIPE){
     r = piperead(f->pipe, addr, n);
   } else if(f->type == FD_DEVICE){
+    if(f->major < 0 || f->major >= NDEV || !devsw[f->major].read)
+      return -1;
     r = devsw[f->major].read(1, addr, n);
   } else if(f->type == FD_INODE){
     ilock(f->ip);
@@ -140,6 +142,8 @@ filewrite(struct file *f, uint64 addr, int n)
   if(f->type == FD_PIPE){
     ret = pipewrite(f->pipe, addr, n);
   } else if(f->type == FD_DEVICE){
+    if(f->major < 0 || f->major >= NDEV || !devsw[f->major].write)
+      return -1;
     ret = devsw[f->major].write(1, addr, n);
   } else if(f->type == FD_INODE){
     // write a few blocks at a time to avoid exceeding

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -116,7 +116,7 @@ fileread(struct file *f, uint64 addr, int n)
   } else if(f->type == FD_DEVICE){
     if(f->major < 0 || f->major >= NDEV || !devsw[f->major].read)
       return -1;
-    r = devsw[f->major].read(1, addr, n);
+    r = devsw[f->major].read(f, 1, addr, n);
   } else if(f->type == FD_INODE){
     ilock(f->ip);
     if((r = readi(f->ip, 1, addr, f->off, n)) > 0)
@@ -144,7 +144,7 @@ filewrite(struct file *f, uint64 addr, int n)
   } else if(f->type == FD_DEVICE){
     if(f->major < 0 || f->major >= NDEV || !devsw[f->major].write)
       return -1;
-    ret = devsw[f->major].write(1, addr, n);
+    ret = devsw[f->major].write(f, 1, addr, n);
   } else if(f->type == FD_INODE){
     // write a few blocks at a time to avoid exceeding
     // the maximum log transaction size, including

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -89,7 +89,7 @@ filestat(struct file *f, uint64 addr)
 {
   struct proc *p = myproc();
   struct stat st;
-  
+
   if(f->type == FD_INODE || f->type == FD_DEVICE){
     ilock(f->ip);
     stati(f->ip, &st);

--- a/kernel/file.h
+++ b/kernel/file.h
@@ -5,8 +5,9 @@ struct file {
   char writable;
   struct pipe *pipe; // FD_PIPE
   struct inode *ip;  // FD_INODE and FD_DEVICE
-  uint off;          // FD_INODE
+  uint off;          // FD_INODE and FD_DEVICE
   short major;       // FD_DEVICE
+  short minor;       // FD_DEVICE
 };
 
 #define major(dev)  ((dev) >> 16 & 0xFFFF)
@@ -31,8 +32,8 @@ struct inode {
 
 // map major device number to device functions.
 struct devsw {
-  int (*read)(int, uint64, int);
-  int (*write)(int, uint64, int);
+  int (*read)(struct file *, int, uint64, int);
+  int (*write)(struct file *, int, uint64, int);
 };
 
 extern struct devsw devsw[];

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -505,10 +505,15 @@ writei(struct inode *ip, int user_src, uint64 src, uint off, uint n)
     brelse(bp);
   }
 
-  if(n > 0 && off > ip->size){
-    ip->size = off;
+  if(n > 0){
+    if(off > ip->size)
+      ip->size = off;
+    // write the i-node back to disk even if the size didn't change
+    // because the loop above might have called bmap() and added a new
+    // block to ip->addrs[].
     iupdate(ip);
   }
+
   return n;
 }
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -232,9 +232,7 @@ growproc(int n)
       return -1;
     }
   } else if(n < 0){
-    if((sz = uvmdealloc(p->pagetable, sz, sz + n)) == 0) {
-      return -1;
-    }
+    sz = uvmdealloc(p->pagetable, sz, sz + n);
   }
   p->sz = sz;
   return 0;

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -20,7 +20,6 @@ fetchaddr(uint64 addr, uint64 *ip)
 }
 
 // Fetch the nul-terminated string at addr from the current process.
-// Doesn't actually copy the string - just sets *pp to point at it.
 // Returns length of string, not including nul, or -1 for error.
 int
 fetchstr(uint64 addr, char *buf, int max)

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -421,10 +421,10 @@ sys_exec(void)
   memset(argv, 0, sizeof(argv));
   for(i=0;; i++){
     if(i >= NELEM(argv)){
-      return -1;
+      goto bad;
     }
     if(fetchaddr(uargv+sizeof(uint64)*i, (uint64*)&uarg) < 0){
-      return -1;
+      goto bad;
     }
     if(uarg == 0){
       argv[i] = 0;
@@ -434,7 +434,7 @@ sys_exec(void)
     if(argv[i] == 0)
       panic("sys_exec kalloc");
     if(fetchstr(uarg, argv[i], PGSIZE) < 0){
-      return -1;
+      goto bad;
     }
   }
 
@@ -444,6 +444,11 @@ sys_exec(void)
     kfree(argv[i]);
 
   return ret;
+
+ bad:
+  for(i = 0; i < NELEM(argv) && argv[i] != 0; i++)
+    kfree(argv[i]);
+  return -1;
 }
 
 uint64

--- a/kernel/sysfile.c
+++ b/kernel/sysfile.c
@@ -333,11 +333,12 @@ sys_open(void)
   if(ip->type == T_DEVICE){
     f->type = FD_DEVICE;
     f->major = ip->major;
+    f->minor = ip->minor;
   } else {
     f->type = FD_INODE;
-    f->off = 0;
   }
   f->ip = ip;
+  f->off = 0;
   f->readable = !(omode & O_WRONLY);
   f->writable = (omode & O_WRONLY) || (omode & O_RDWR);
 

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -270,7 +270,8 @@ uvmdealloc(pagetable_t pagetable, uint64 oldsz, uint64 newsz)
     return oldsz;
 
   uint64 newup = PGROUNDUP(newsz);
-  uvmunmap(pagetable, newup, oldsz - newup, 1);
+  if(newup < PGROUNDUP(oldsz))
+    uvmunmap(pagetable, newup, oldsz - newup, 1);
 
   return newsz;
 }

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -359,7 +359,7 @@ copyout(pagetable_t pagetable, uint64 dstva, char *src, uint64 len)
   uint64 n, va0, pa0;
 
   while(len > 0){
-    va0 = (uint)PGROUNDDOWN(dstva);
+    va0 = PGROUNDDOWN(dstva);
     pa0 = walkaddr(pagetable, va0);
     if(pa0 == 0)
       return -1;
@@ -384,7 +384,7 @@ copyin(pagetable_t pagetable, char *dst, uint64 srcva, uint64 len)
   uint64 n, va0, pa0;
 
   while(len > 0){
-    va0 = (uint)PGROUNDDOWN(srcva);
+    va0 = PGROUNDDOWN(srcva);
     pa0 = walkaddr(pagetable, va0);
     if(pa0 == 0)
       return -1;

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -268,7 +268,10 @@ uvmdealloc(pagetable_t pagetable, uint64 oldsz, uint64 newsz)
 {
   if(newsz >= oldsz)
     return oldsz;
-  uvmunmap(pagetable, newsz, oldsz - newsz, 1);
+
+  uint64 newup = PGROUNDUP(newsz);
+  uvmunmap(pagetable, newup, oldsz - newup, 1);
+
   return newsz;
 }
 

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -99,6 +99,9 @@ walkaddr(pagetable_t pagetable, uint64 va)
   pte_t *pte;
   uint64 pa;
 
+  if(va >= MAXVA)
+    return 0;
+
   pte = walk(pagetable, va, 0);
   if(pte == 0)
     return 0;
@@ -408,7 +411,7 @@ copyinstr(pagetable_t pagetable, char *dst, uint64 srcva, uint64 max)
   int got_null = 0;
 
   while(got_null == 0 && max > 0){
-    va0 = (uint)PGROUNDDOWN(srcva);
+    va0 = PGROUNDDOWN(srcva);
     pa0 = walkaddr(pagetable, va0);
     if(pa0 == 0)
       return -1;

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1757,7 +1757,7 @@ sbrkarg(char *s)
     printf("%s: open sbrk failed\n", s);
     exit(1);
   }
-  if ((n = write(fd, a, 10)) < 0) {
+  if ((n = write(fd, a, PGSIZE)) < 0) {
     printf("%s: write sbrk failed\n", s);
     exit(1);
   }

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -2016,6 +2016,7 @@ sbrkbugs(char *s)
 // has this bug, it will panic: balloc: out of blocks. 
 // assumed_free may need to be raised to be
 // more than the number of free blocks.
+// this test takes a long time.
 void
 badwrite(char *s)
 {
@@ -2045,6 +2046,22 @@ badwrite(char *s)
   close(fd);
   unlink("junk");
 
+  exit(0);
+}
+
+// test whether exec() leaks memory if one of the
+// arguments is invalid. the test passes if
+// the kernel doesn't panic.
+void
+badarg(char *s)
+{
+  for(int i = 0; i < 50000; i++){
+    char *argv[2];
+    argv[0] = (char*)0xffffffff;
+    argv[1] = 0;
+    exec("echo", argv);
+  }
+  
   exit(0);
 }
 
@@ -2087,7 +2104,8 @@ main(int argc, char *argv[])
   } tests[] = {
     {pgbug, "pgbug" },
     {sbrkbugs, "sbrkbugs" },
-    {badwrite, "badwrite" },
+    // {badwrite, "badwrite" },
+    {badarg, "badarg" },
     {reparent, "reparent" },
     {twochildren, "twochildren"},
     {forkfork, "forkfork"},

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1558,16 +1558,11 @@ forktest(char *s)
 }
 
 void
-sbrktest(char *s)
+sbrkbasic(char *s)
 {
-  enum { BIG=100*1024*1024, TOOMUCH=1024*1024*1024};
-  int i, fds[2], pids[10], pid, ppid;
-  char *c, *oldbrk, scratch, *a, *b, *lastaddr, *p;
-  uint64 amt;
-  int fd;
-  int n;
-
-  oldbrk = sbrk(0);
+  enum { TOOMUCH=1024*1024*1024};
+  int i, pid, xstatus;
+  char *c, *a, *b;
 
   // does sbrk() return the expected failure value?
   a = sbrk(TOOMUCH);
@@ -1600,7 +1595,21 @@ sbrktest(char *s)
   }
   if(pid == 0)
     exit(0);
-  wait(0);
+  wait(&xstatus);
+  exit(xstatus);
+}
+
+void
+sbrkmuch(char *s)
+{
+  enum { BIG=100*1024*1024, TOOMUCH=1024*1024*1024};
+  int i, fds[2], pids[10], pid, ppid;
+  char *c, *oldbrk, scratch, *a, *lastaddr, *p;
+  uint64 amt;
+  int fd;
+  int n;
+
+  oldbrk = sbrk(0);
 
   // can one grow address space to something big?
   a = sbrk(0);
@@ -2076,7 +2085,8 @@ main(int argc, char *argv[])
     {bigargtest, "bigargtest"},
     {bigwrite, "bigwrite"},
     {bsstest, "bsstest"},
-    {sbrktest, "sbrktest"},
+    {sbrkbasic, "sbrkbasic"},
+    {sbrkmuch, "sbrkmuch"},
     {validatetest, "validatetest"},
     {stacktest, "stacktest"},
     {opentest, "opentest"},

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1908,6 +1908,18 @@ stacktest(char *s)
     exit(xstatus);
 }
 
+// copyinstr() used to cast the virtual page address to uint,
+// which (with certain wild system call arguments) could
+// result in a kernel page fault.
+void
+pgbug(char *s)
+{
+  char *argv[1];
+  argv[0] = 0;
+  exec((char*)0xeaeb0b5b00002f5e, argv);
+  exit(0);
+}
+
 // run each test in its own process. run returns 1 if child's exit()
 // indicates success.
 int
@@ -1945,6 +1957,7 @@ main(int argc, char *argv[])
     void (*f)(char *);
     char *s;
   } tests[] = {
+    {pgbug, "pgbug" },
     {reparent, "reparent" },
     {twochildren, "twochildren"},
     {forkfork, "forkfork"},

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -598,6 +598,7 @@ forkforkfork(char *s)
   sleep(10); // one second
 }
 
+// allocate all mem, free it, and allocate again
 void
 mem(char *s)
 {
@@ -1907,7 +1908,8 @@ stacktest(char *s)
     exit(xstatus);
 }
 
-// 1 if successful
+// run each test in its own process. run returns 1 if child's exit()
+// indicates success.
 int
 run(void f(char *), char *s) {
   int pid;

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1908,15 +1908,18 @@ stacktest(char *s)
     exit(xstatus);
 }
 
-// copyinstr() used to cast the virtual page address to uint,
-// which (with certain wild system call arguments) could
-// result in a kernel page fault.
+// copyin(), copyout(), and copyinstr() used to cast the virtual page
+// address to uint, which (with certain wild system call arguments)
+// resulted in a kernel page faults.
 void
 pgbug(char *s)
 {
   char *argv[1];
   argv[0] = 0;
   exec((char*)0xeaeb0b5b00002f5e, argv);
+
+  pipe((int*)0xeaeb0b5b00002f5e);
+
   exit(0);
 }
 

--- a/user/usertests.c
+++ b/user/usertests.c
@@ -1915,6 +1915,7 @@ run(void f(char *), char *s) {
   int pid;
   int xstatus;
   
+  printf("test %s: ", s);
   if((pid = fork()) < 0) {
     printf("runtest: fork error\n");
     exit(1);
@@ -1925,9 +1926,9 @@ run(void f(char *), char *s) {
   } else {
     wait(&xstatus);
     if(xstatus != 0) 
-      printf("test %s FAILED\n", s);
+      printf("FAILED\n", s);
     else
-      printf("test %s OK\n", s);
+      printf("OK\n", s);
     return xstatus == 0;
   }
 }
@@ -1988,7 +1989,7 @@ main(int argc, char *argv[])
   printf("usertests starting\n");
 
   if(open("usertests.ran", 0) >= 0){
-    printf("already ran user tests -- rebuild fs.img (make fs.img)\n");
+    printf("already ran user tests -- rebuild fs.img (rm fs.img; make fs.img)\n");
     exit(1);
   }
   close(open("usertests.ran", O_CREATE));


### PR DESCRIPTION
El propósito de este PR es aprobar un fast-foward de 02247fb22b72e8d3851f7834336c319380002117 a b3227c6a37e1e8388e04702cc5c2ab03d3a53ebc, para tener este commit: d1e2ce71d411d30a57b5c60714cc09ef69e0ae6e _(Update grading script to only run alloctest once)_, y por tanto cerrar parte de #1. (Como Github no permite hacer fast-foward desde la web, el push se tendrá que hacer a mano.)

Nota: el fast-forward incluye cambios al upstream de xv6, de los que upstream hizo merge para lab-lazy, pero no para lab alloc. Los tests, sin embargo, siguen pasando. Verificación realizada:

  - hice rebase de la solución de @sjdalessandro (https://github.com/fisop/xv6-private/commit/11d6b4457f22acf5052e7ae1e395a8b09f25823c y https://github.com/fisop/xv6-private/commit/1247e8401e0efcc50ed3ce5899184ba223e3d26f) sobre el fast-forward, y passa los checks:

    ```
    running alloctest:
    $ make qemu-gdb
    (12.7s)
      filetest: OK
      memtest: OK
    usertests:
    $ make qemu-gdb
    OK (143.4s)
    Score: 100/100
    ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fisop/xv6-riscv/2)
<!-- Reviewable:end -->
