### PR TITLE
Usar la funcionalidad "terminate_match" en grade-lab-alloc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OBJS = \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
-#TOOLPREFIX = 
+#TOOLPREFIX =
 
 # Try to infer the correct TOOLPREFIX if not set
 ifndef TOOLPREFIX
@@ -74,7 +74,7 @@ endif
 LDFLAGS = -z max-page-size=4096
 
 $K/kernel: $(OBJS) $K/kernel.ld $U/initcode
-	$(LD) $(LDFLAGS) -T $K/kernel.ld -o $K/kernel $(OBJS) 
+	$(LD) $(LDFLAGS) -T $K/kernel.ld -o $K/kernel $(OBJS)
 	$(OBJDUMP) -S $K/kernel > $K/kernel.asm
 	$(OBJDUMP) -t $K/kernel | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $K/kernel.sym
 
@@ -150,7 +150,7 @@ fs.img: mkfs/mkfs README user/xargstest.sh $(UPROGS)
 
 -include kernel/*.d user/*.d
 
-clean: 
+clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
 	*/*.o */*.d */*.asm */*.sym \
 	$U/initcode $U/initcode.out $K/kernel fs.img \

--- a/grade-lab-alloc
+++ b/grade-lab-alloc
@@ -7,9 +7,9 @@ r = Runner(save("xv6.out"))
 
 @test(0, "running alloctest")
 def test_alloctest():
-    r.run_qemu(shell_script([
-        'alloctest'
-    ]))
+    r.run_qemu(shell_script(
+        ['alloctest'],
+        terminate_match="^memtest: (OK|FAILED)$|panic: "))
 
 @test(30, "filetest", parent=test_alloctest)
 def test_filetest():
@@ -21,9 +21,9 @@ def test_memtest():
 
 @test(20, "usertests")
 def test_usertests():
-    r.run_qemu(shell_script([
-        'usertests'
-    ]), timeout=150)
+    r.run_qemu(shell_script(['usertests'],
+                            terminate_match=ALL_TESTS_RE),
+               timeout=150)
     r.match('^ALL TESTS PASSED$')
 
 run_tests()

--- a/gradelib.py
+++ b/gradelib.py
@@ -7,6 +7,14 @@ from optparse import OptionParser
 __all__ = []
 
 ##################################################################
+# Default completion regex
+#
+
+__all__ += ["ALL_TESTS_RE"]
+
+ALL_TESTS_RE = "^(SOME TESTS FAILED|ALL TESTS PASSED)$|panic: "
+
+##################################################################
 # Test structure
 #
 
@@ -574,7 +582,8 @@ def shell_script(script, terminate_match=None):
         def handle_output(output):
             context.buf.extend(output)
             if terminate_match is not None:
-                if re.match(terminate_match, context.buf.decode('utf-8', 'replace')):
+                if re.search(terminate_match,
+                             context.buf.decode('utf-8', 'replace'), re.M):
                     raise TerminateTest
             if b'$ ' in context.buf:
                 context.buf = bytearray()

--- a/kernel/buddy.c
+++ b/kernel/buddy.c
@@ -12,7 +12,7 @@ static int nsizes;     // the number of entries in bd_sizes array
 #define LEAF_SIZE     16                         // The smallest block size
 #define MAXSIZE       (nsizes-1)                 // Largest index in bd_sizes array
 #define BLK_SIZE(k)   ((1L << (k)) * LEAF_SIZE)  // Size of block at size k
-#define HEAP_SIZE     BLK_SIZE(MAXSIZE) 
+#define HEAP_SIZE     BLK_SIZE(MAXSIZE)
 #define NBLK(k)       (1 << (MAXSIZE-k))         // Number of block at size k
 #define ROUNDUP(n,sz) (((((n)-1)/(sz))+1)*(sz))  // Round up to the next multiple of sz
 
@@ -31,7 +31,7 @@ struct sz_info {
 };
 typedef struct sz_info Sz_info;
 
-static Sz_info *bd_sizes; 
+static Sz_info *bd_sizes;
 static void *bd_base;   // start address of memory managed by the buddy allocator
 static struct spinlock lock;
 
@@ -60,7 +60,7 @@ void bit_clear(char *array, int index) {
 void
 bd_print_vector(char *vector, int len) {
   int last, lb;
-  
+
   last = 1;
   lb = 0;
   for (int b = 0; b < len; b++) {
@@ -212,7 +212,7 @@ log2(uint64 n) {
   return k;
 }
 
-// Mark memory from [start, stop), starting at size 0, as allocated. 
+// Mark memory from [start, stop), starting at size 0, as allocated.
 void
 bd_mark(void *start, void *stop)
 {
@@ -250,7 +250,7 @@ bd_initfree_pair(int k, int bi) {
   }
   return free;
 }
-  
+
 // Initialize the free lists for each size k.  For each size k, there
 // are only two pairs that may have a buddy that should be on free list:
 // bd_left and bd_right.
@@ -336,12 +336,12 @@ bd_init(void *base, void *end) {
   // done allocating; mark the memory range [base, p) as allocated, so
   // that buddy will not hand out that memory.
   int meta = bd_mark_data_structures(p);
-  
+
   // mark the unavailable memory range [end, HEAP_SIZE) as allocated,
   // so that buddy will not hand out that memory.
   int unavailable = bd_mark_unavailable(end, p);
   void *bd_end = bd_base+BLK_SIZE(MAXSIZE)-unavailable;
-  
+
   // initialize free lists for each size k
   int free = bd_initfree(p, bd_end);
 

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -89,7 +89,7 @@ filestat(struct file *f, uint64 addr)
 {
   struct proc *p = myproc();
   struct stat st;
-  
+
   if(f->type == FD_INODE || f->type == FD_DEVICE){
     ilock(f->ip);
     stati(f->ip, &st);


### PR DESCRIPTION

El parámetro terminate_match permite indicar a los tests las condiciones
en las que se debería abortar el test: por ejemplo, una llamada a panic().
Con esto, se consigue no tener que tener que esperar al timeout si ello
sucede.

En el commit se incluye:

  - una expresión regular específica para alloctest

  - una expresión regular específica para usertests, definida en gradelib.py
    para poder ser usada en futuros labs

Nota: la llamada a re.match() en gradelib se cambia a re.search() para evitar
tener que especificar ".*" innecesariamente; y se añade el flag re.MULTILINE
para aquellos matchers con anclaje.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fisop/xv6-riscv/3)
<!-- Reviewable:end -->
